### PR TITLE
피처 스토어 관리 기능 추가 (clear, migrate, list 개선)

### DIFF
--- a/feat/migration/1.list-plan.md
+++ b/feat/migration/1.list-plan.md
@@ -1,0 +1,137 @@
+# 1단계: List 기능 개선 상세 계획
+
+## 현재 상황 분석
+
+### 기존 동작
+- **파일**: `src/sagemaker_fs_cli/commands/list_cmd.py:25`
+- **필터 조건**: `if fg_details.get('OnlineStoreConfig'):`
+- **결과**: 온라인 스토어가 활성화된 피처그룹만 표시
+
+### 기존 출력 정보
+```
+FeatureGroupName | Status | IngestMode | StorageType | TTL | EventTimeFeature | RecordIdFeature | TableFormat | CreationTime
+```
+
+## 요구사항
+- 오프라인 전용 피처그룹도 목록에 표시
+- 온라인+오프라인, 오프라인 전용 구분 명확히 표시
+
+## 변경 계획
+
+### 1. 필터 조건 수정
+**위치**: `list_cmd.py:25`
+
+**기존**:
+```python
+if fg_details.get('OnlineStoreConfig'):
+```
+
+**변경**:
+```python
+# 온라인 또는 오프라인 스토어가 하나라도 있으면 포함
+online_config = fg_details.get('OnlineStoreConfig')
+offline_config = fg_details.get('OfflineStoreConfig')
+
+if online_config or offline_config:
+```
+
+### 2. IngestMode 로직 개선
+**위치**: `list_cmd.py:41-47`
+
+**기존 로직**:
+- 온라인 스토어만 고려하여 IngestMode 결정
+
+**개선된 로직**:
+- 온라인 전용: "Online"
+- 오프라인 전용: "Offline" 
+- 온라인+오프라인: "Online + Offline"
+
+### 3. 오프라인 전용 그룹 정보 처리
+**새로운 처리 로직**:
+- 온라인 스토어 정보가 없는 경우의 기본값 설정
+- StorageType: "N/A" (온라인 스토어 없음)
+- TTL: "N/A" (온라인 스토어 없음)
+
+### 4. 테이블 출력 개선
+**위치**: `src/sagemaker_fs_cli/utils/formatter.py:31-59`
+
+**현재 헤더**:
+```python
+headers = [
+    'FeatureGroupName', 'Status', 'IngestMode', 'StorageType', 'TTL',
+    'EventTimeFeature', 'RecordIdFeature', 'TableFormat', 'CreationTime'
+]
+```
+
+**개선점**:
+- IngestMode 컬럼을 더 명확하게 표시
+- 오프라인 전용 그룹의 경우 StorageType, TTL은 "N/A"로 표시
+- TableFormat는 오프라인 스토어 설정에서 가져오기
+
+## 구현 단계
+
+### Step 1: list_cmd.py 수정
+1. **필터 조건 변경** (라인 25)
+2. **IngestMode 로직 개선** (라인 41-47) 
+3. **오프라인 전용 그룹 처리** (라인 26-62)
+
+### Step 2: 테스트 케이스 정의
+- 온라인 전용 피처그룹
+- 오프라인 전용 피처그룹  
+- 온라인+오프라인 피처그룹
+- 빈 결과 처리
+
+## 예상 결과
+
+### Before (현재)
+```
+FeatureGroupName | Status    | IngestMode      | StorageType | TTL | ...
+my-online-fg     | Created   | Online          | Standard    | N/A | ...
+my-hybrid-fg     | Created   | Online + Offline| Standard    | N/A | ...
+```
+
+### After (개선 후)
+```
+FeatureGroupName | Status    | IngestMode      | StorageType | TTL | TableFormat | ...
+my-online-fg     | Created   | Online          | Standard    | N/A | N/A         | ...
+my-offline-fg    | Created   | Offline         | N/A         | N/A | Iceberg     | ...
+my-hybrid-fg     | Created   | Online + Offline| Standard    | N/A | Iceberg     | ...
+```
+
+## 코드 변경 포인트
+
+### 1. list_cmd.py - 필터 로직
+```python
+# 라인 25 변경
+if online_config or offline_config:
+```
+
+### 2. list_cmd.py - IngestMode 결정 로직
+```python
+# 라인 41-47 변경
+ingest_mode = []
+if online_config:
+    ingest_mode.append('Online')
+if offline_config:
+    ingest_mode.append('Offline')
+ingest_mode_str = ' + '.join(ingest_mode) if ingest_mode else 'Unknown'
+```
+
+### 3. list_cmd.py - 오프라인 전용 그룹 처리
+```python
+# 온라인 스토어 정보 (없을 수 있음)
+storage_type = online_config.get('StorageType', 'N/A') if online_config else 'N/A'
+ttl_duration = online_config.get('TtlDuration') if online_config else None
+```
+
+## 검증 방법
+1. 온라인 전용 피처그룹이 있는 환경에서 테스트
+2. 오프라인 전용 피처그룹이 있는 환경에서 테스트  
+3. 혼합 환경에서 테스트
+4. 빈 환경에서 테스트
+
+## 위험도 평가
+- **위험도**: 낮음
+- **영향 범위**: list 명령어만
+- **호환성**: 기존 기능에 영향 없음
+- **롤백**: 쉬움 (단순 조건문 변경)

--- a/feat/migration/2.clear-plan.md
+++ b/feat/migration/2.clear-plan.md
@@ -1,0 +1,259 @@
+# 2단계: Clear 기능 구현 상세 계획
+
+## 목적
+Feature Store의 모든 데이터를 삭제하여 빈 상태로 만드는 기능
+
+## 요구사항
+1. **온라인 스토어 삭제**: 모든 레코드 삭제
+2. **오프라인 스토어 삭제**: S3 데이터 삭제
+3. **선택적 삭제**: 온라인만, 오프라인만, 또는 둘 다
+4. **안전장치**: 확인 프롬프트, 백업 옵션
+5. **진행상황 표시**: 삭제 진행률 표시
+
+## CLI 인터페이스 설계
+
+### 기본 명령어
+```bash
+sagemaker-fs clear <feature-group-name> [OPTIONS]
+```
+
+### 옵션들
+- `--online-only`: 온라인 스토어만 삭제
+- `--offline-only`: 오프라인 스토어만 삭제  
+- `--force`: 확인 프롬프트 없이 즉시 삭제
+- `--backup-s3 <s3-path>`: 삭제 전 S3에 백업
+- `--dry-run`: 실제 삭제 없이 계획만 확인
+
+### 예시
+```bash
+# 모든 데이터 삭제 (확인 프롬프트 표시)
+sagemaker-fs clear my-feature-group
+
+# 온라인 스토어만 삭제
+sagemaker-fs clear my-feature-group --online-only
+
+# 백업 후 삭제
+sagemaker-fs clear my-feature-group --backup-s3 s3://my-backup/fg-backup/
+
+# 강제 삭제 (확인 없음)
+sagemaker-fs clear my-feature-group --force
+```
+
+## 구현 설계
+
+### 1. 파일 구조
+```
+src/sagemaker_fs_cli/commands/
+└── clear_cmd.py              # 새로 생성
+```
+
+### 2. clear_cmd.py 구조
+```python
+def clear_feature_group(config, feature_group_name, **options):
+    """메인 진입점"""
+    
+def _validate_feature_group(config, feature_group_name):
+    """피처그룹 존재 및 설정 확인"""
+    
+def _confirm_deletion(feature_group_name, options):
+    """사용자 확인 프롬프트"""
+    
+def _backup_to_s3(config, feature_group_name, backup_path):
+    """S3 백업 생성"""
+    
+def _clear_online_store(config, feature_group_name):
+    """온라인 스토어 데이터 삭제"""
+    
+def _clear_offline_store(config, feature_group_name):
+    """오프라인 스토어 데이터 삭제"""
+    
+def _get_all_record_ids(config, feature_group_name):
+    """모든 레코드 ID 조회 (온라인 스토어 삭제용)"""
+```
+
+### 3. CLI 통합 (cli.py에 추가)
+```python
+@cli.command('clear')
+@click.argument('feature_group_name')
+@click.option('--online-only', is_flag=True, help='온라인 스토어만 삭제')
+@click.option('--offline-only', is_flag=True, help='오프라인 스토어만 삭제')
+@click.option('--force', is_flag=True, help='확인 없이 즉시 삭제')
+@click.option('--backup-s3', help='삭제 전 S3 백업 경로')
+@click.option('--dry-run', is_flag=True, help='실제 삭제 없이 계획만 확인')
+@click.pass_context
+def clear_feature_group(ctx, feature_group_name, online_only, offline_only, force, backup_s3, dry_run):
+    """피처 그룹의 모든 데이터 삭제"""
+```
+
+## 핵심 구현 로직
+
+### 1. 온라인 스토어 삭제
+**도전과제**: SageMaker FeatureStore에는 "모든 레코드 삭제" API가 없음
+
+**해결책**: 
+1. **방법 1 (권장)**: Athena를 통해 모든 record_id 조회 후 배치 삭제
+2. **방법 2**: 사용자가 제공한 record_id 목록으로 삭제
+3. **방법 3**: Feature Group 재생성 (가장 확실하지만 위험)
+
+**구현**:
+```python
+def _clear_online_store(config, feature_group_name):
+    # 1. Athena를 통해 모든 record_id 조회
+    query = f"SELECT {record_id_feature} FROM {athena_table}"
+    record_ids = _execute_athena_query(config, query)
+    
+    # 2. 배치로 레코드 삭제 (DeleteRecord API 사용)
+    for batch in _batch_records(record_ids, batch_size=25):
+        for record_id in batch:
+            config.featurestore_runtime.delete_record(
+                FeatureGroupName=feature_group_name,
+                RecordIdentifierValueAsString=str(record_id)
+            )
+```
+
+### 2. 오프라인 스토어 삭제  
+```python
+def _clear_offline_store(config, feature_group_name, fg_details):
+    # S3 경로 추출
+    s3_config = fg_details['OfflineStoreConfig']['S3StorageConfig']
+    s3_uri = s3_config['S3Uri']
+    
+    # S3 객체들 삭제
+    s3_client = config.session.client('s3')
+    bucket, prefix = _parse_s3_uri(s3_uri)
+    
+    paginator = s3_client.get_paginator('list_objects_v2')
+    for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+        if 'Contents' in page:
+            objects = [{'Key': obj['Key']} for obj in page['Contents']]
+            s3_client.delete_objects(
+                Bucket=bucket,
+                Delete={'Objects': objects}
+            )
+```
+
+### 3. 백업 기능
+```python
+def _backup_to_s3(config, feature_group_name, backup_path, fg_details):
+    # 오프라인 스토어 데이터를 백업 위치로 복사
+    source_s3_uri = fg_details['OfflineStoreConfig']['S3StorageConfig']['S3Uri']
+    
+    # S3 to S3 복사
+    s3_client = config.session.client('s3')
+    # ... S3 복사 로직
+```
+
+### 4. 안전장치
+```python
+def _confirm_deletion(feature_group_name, options):
+    if options.get('force'):
+        return True
+        
+    stores_to_clear = []
+    if options.get('online_only'):
+        stores_to_clear.append("온라인 스토어")
+    elif options.get('offline_only'):
+        stores_to_clear.append("오프라인 스토어")
+    else:
+        stores_to_clear.extend(["온라인 스토어", "오프라인 스토어"])
+    
+    stores_str = ", ".join(stores_to_clear)
+    
+    click.echo(f"⚠️  경고: '{feature_group_name}'의 {stores_str} 데이터가 완전히 삭제됩니다.")
+    click.echo("이 작업은 되돌릴 수 없습니다!")
+    
+    return click.confirm("정말로 계속하시겠습니까?")
+```
+
+## 에러 처리
+
+### 1. API 제한 처리
+```python
+import time
+from botocore.exceptions import ClientError
+
+def _handle_throttling(func, *args, **kwargs):
+    max_retries = 5
+    base_delay = 1
+    
+    for attempt in range(max_retries):
+        try:
+            return func(*args, **kwargs)
+        except ClientError as e:
+            if e.response['Error']['Code'] == 'ThrottlingException':
+                delay = base_delay * (2 ** attempt)
+                time.sleep(delay)
+                continue
+            raise
+```
+
+### 2. 진행상황 표시
+```python
+from tqdm import tqdm
+
+def _delete_records_with_progress(config, feature_group_name, record_ids):
+    with tqdm(total=len(record_ids), desc="레코드 삭제 중") as pbar:
+        for record_id in record_ids:
+            _handle_throttling(
+                config.featurestore_runtime.delete_record,
+                FeatureGroupName=feature_group_name,
+                RecordIdentifierValueAsString=str(record_id)
+            )
+            pbar.update(1)
+```
+
+## 구현 단계
+
+### Step 1: clear_cmd.py 기본 구조 생성
+- 파일 생성 및 기본 함수들 구현
+- 피처그룹 검증 로직
+
+### Step 2: 온라인 스토어 삭제 구현
+- Athena 쿼리를 통한 record_id 조회
+- 배치 삭제 로직
+
+### Step 3: 오프라인 스토어 삭제 구현  
+- S3 객체 삭제 로직
+
+### Step 4: 백업 기능 구현
+- S3 to S3 복사
+
+### Step 5: CLI 통합
+- cli.py에 clear 명령어 추가
+
+### Step 6: 안전장치 및 UX 개선
+- 확인 프롬프트, 진행률 표시
+
+## 테스트 계획
+
+### 1. 단위 테스트
+- 각 함수별 개별 테스트
+- Mock을 사용한 AWS API 테스트
+
+### 2. 통합 테스트  
+- 테스트용 피처그룹으로 전체 플로우 테스트
+
+### 3. 에러 케이스 테스트
+- 존재하지 않는 피처그룹
+- 권한 부족
+- API 제한 시나리오
+
+## 위험도 및 고려사항
+
+### 위험도: 높음
+- **데이터 손실**: 실수로 중요한 데이터 삭제 가능
+- **비가역성**: 삭제된 데이터 복구 불가능
+
+### 완화 방안
+1. **다중 확인**: force 플래그 없으면 반드시 확인
+2. **Dry-run 모드**: 실제 실행 전 계획 확인  
+3. **백업 옵션**: 삭제 전 자동 백업
+4. **상세 로깅**: 모든 삭제 작업 로그 기록
+
+## 필요한 의존성
+```python
+# 추가 패키지 (requirements.txt)
+tqdm>=4.65.0  # 진행률 표시
+```
+
+이 계획으로 구현을 진행할까요?

--- a/feat/migration/3.migrate-plan.md
+++ b/feat/migration/3.migrate-plan.md
@@ -1,0 +1,388 @@
+# 3단계: Migration 기능 구현 상세 계획
+
+## 목적
+Feature Store 간 데이터 마이그레이션 기능 구현
+- Offline → Online+Offline
+- Online+Offline → Online+Offline
+
+## 요구사항
+1. **스키마 호환성 검증**: 소스와 타겟의 피처 정의 호환성 확인
+2. **데이터 마이그레이션**: 배치 처리를 통한 대용량 데이터 이동
+3. **타겟 정리**: `--clear-target` 옵션으로 타겟 데이터 사전 삭제
+4. **진행상황 모니터링**: 실시간 진행률 및 상태 표시
+5. **에러 처리**: 실패한 레코드 추적 및 재시도
+6. **Dry-run**: 실제 마이그레이션 전 계획 확인
+
+## CLI 인터페이스 설계
+
+### 기본 명령어
+```bash
+sagemaker-fs migrate <source-feature-group> <target-feature-group> [OPTIONS]
+```
+
+### 옵션들
+- `--clear-target`: 타겟 피처그룹의 기존 데이터 삭제
+- `--batch-size <N>`: 배치 처리 사이즈 (기본: 100)
+- `--max-workers <N>`: 동시 처리 워커 수 (기본: 4)
+- `--dry-run`: 실제 마이그레이션 없이 계획만 확인
+- `--resume-from <record-id>`: 특정 레코드부터 재개
+- `--filter-query <sql>`: 마이그레이션할 데이터 필터링
+
+### 예시
+```bash
+# 기본 마이그레이션
+sagemaker-fs migrate source-fg target-fg
+
+# 타겟 데이터 삭제 후 마이그레이션
+sagemaker-fs migrate source-fg target-fg --clear-target
+
+# 배치 사이즈 조정
+sagemaker-fs migrate source-fg target-fg --batch-size 50 --max-workers 8
+
+# 특정 조건의 데이터만 마이그레이션
+sagemaker-fs migrate source-fg target-fg --filter-query "WHERE created_date >= '2024-01-01'"
+```
+
+## 아키텍처 설계
+
+### 1. 파일 구조
+```
+src/sagemaker_fs_cli/commands/
+└── migrate_cmd.py              # 새로 생성
+```
+
+### 2. migrate_cmd.py 구조
+```python
+def migrate_feature_group(config, source_name, target_name, **options):
+    """메인 마이그레이션 진입점"""
+    
+def _validate_migration_compatibility(config, source_fg, target_fg):
+    """소스-타겟 호환성 검증"""
+    
+def _plan_migration(config, source_fg, target_fg, options):
+    """마이그레이션 계획 수립"""
+    
+def _execute_migration(config, source_fg, target_fg, migration_plan):
+    """실제 마이그레이션 실행"""
+    
+def _extract_from_offline_store(config, source_fg, filter_query, batch_size):
+    """오프라인 스토어에서 데이터 추출"""
+    
+def _load_to_online_store(config, target_fg, records_batch):
+    """온라인 스토어로 데이터 로드"""
+    
+def _extract_from_online_store(config, source_fg, batch_size):
+    """온라인 스토어에서 데이터 추출"""
+```
+
+## 핵심 구현 로직
+
+### 1. 스키마 호환성 검증
+```python
+def _validate_migration_compatibility(config, source_fg, target_fg):
+    """스키마 호환성 검증"""
+    
+    # 피처 정의 비교
+    source_features = {f['FeatureName']: f for f in source_fg['FeatureDefinitions']}
+    target_features = {f['FeatureName']: f for f in target_fg['FeatureDefinitions']}
+    
+    # 필수 피처 존재 확인
+    missing_features = set(target_features.keys()) - set(source_features.keys())
+    if missing_features:
+        raise ValueError(f"타겟에 있지만 소스에 없는 피처: {missing_features}")
+    
+    # 데이터 타입 호환성 확인
+    incompatible_features = []
+    for fname, target_feat in target_features.items():
+        if fname in source_features:
+            source_feat = source_features[fname]
+            if not _is_type_compatible(source_feat['FeatureType'], target_feat['FeatureType']):
+                incompatible_features.append((fname, source_feat['FeatureType'], target_feat['FeatureType']))
+    
+    if incompatible_features:
+        raise ValueError(f"호환되지 않는 피처 타입: {incompatible_features}")
+    
+    # RecordIdentifier와 EventTime 피처 확인
+    if source_fg['RecordIdentifierFeatureName'] != target_fg['RecordIdentifierFeatureName']:
+        raise ValueError("RecordIdentifierFeatureName이 다릅니다")
+    
+    if source_fg['EventTimeFeatureName'] != target_fg['EventTimeFeatureName']:
+        raise ValueError("EventTimeFeatureName이 다릅니다")
+```
+
+### 2. 마이그레이션 실행 엔진
+```python
+def _execute_migration(config, source_fg, target_fg, migration_plan):
+    """마이그레이션 실행"""
+    
+    source_type = migration_plan['source_type']  # 'offline', 'online+offline'
+    target_type = migration_plan['target_type']
+    total_records = migration_plan['estimated_records']
+    
+    # 진행률 추적
+    with tqdm(total=total_records, desc="마이그레이션 진행 중") as pbar:
+        failed_records = []
+        
+        # 데이터 소스에 따른 처리
+        if source_type == 'offline':
+            # Athena를 통한 오프라인 스토어 읽기
+            for batch in _extract_from_offline_store(config, source_fg, migration_plan):
+                success_count, failures = _load_to_online_store(config, target_fg, batch)
+                failed_records.extend(failures)
+                pbar.update(len(batch))
+                
+        elif 'online' in source_type:
+            # 온라인 스토어에서 읽기 + 오프라인 스토어 병합
+            for batch in _extract_from_hybrid_store(config, source_fg, migration_plan):
+                success_count, failures = _load_to_online_store(config, target_fg, batch)
+                failed_records.extend(failures)
+                pbar.update(len(batch))
+    
+    return {
+        'total_processed': pbar.n,
+        'failed_records': failed_records,
+        'success_rate': (pbar.n - len(failed_records)) / pbar.n if pbar.n > 0 else 0
+    }
+```
+
+### 3. 오프라인 스토어 데이터 추출
+```python
+def _extract_from_offline_store(config, source_fg, filter_query=None, batch_size=100):
+    """Athena를 통한 오프라인 스토어 데이터 추출"""
+    
+    athena_client = config.session.client('athena')
+    database = 'sagemaker_featurestore'
+    table = source_fg['FeatureGroupName'].replace('-', '_')
+    
+    # 기본 쿼리 구성
+    base_query = f"SELECT * FROM {database}.{table}"
+    if filter_query:
+        query = f"{base_query} {filter_query}"
+    else:
+        query = base_query
+    
+    # Athena 쿼리 실행
+    response = athena_client.start_query_execution(
+        QueryString=query,
+        ResultConfiguration={
+            'OutputLocation': 's3://temp-query-results/'
+        }
+    )
+    
+    query_execution_id = response['QueryExecutionId']
+    
+    # 쿼리 완료 대기
+    _wait_for_query_completion(athena_client, query_execution_id)
+    
+    # 결과를 배치로 읽기
+    paginator = athena_client.get_paginator('get_query_results')
+    current_batch = []
+    
+    for page in paginator.paginate(QueryExecutionId=query_execution_id):
+        rows = page['ResultSet']['Rows'][1:]  # 헤더 스킵
+        
+        for row in rows:
+            record = _convert_athena_row_to_record(row, source_fg['FeatureDefinitions'])
+            current_batch.append(record)
+            
+            if len(current_batch) >= batch_size:
+                yield current_batch
+                current_batch = []
+    
+    if current_batch:
+        yield current_batch
+```
+
+### 4. 온라인 스토어 데이터 로드
+```python
+def _load_to_online_store(config, target_fg, records_batch):
+    """온라인 스토어로 배치 데이터 로드"""
+    
+    featurestore_runtime = config.session.client('sagemaker-featurestore-runtime')
+    target_name = target_fg['FeatureGroupName']
+    
+    success_count = 0
+    failures = []
+    
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        # 각 레코드를 병렬로 처리
+        future_to_record = {
+            executor.submit(_put_single_record, featurestore_runtime, target_name, record): record
+            for record in records_batch
+        }
+        
+        for future in as_completed(future_to_record):
+            record = future_to_record[future]
+            try:
+                future.result()
+                success_count += 1
+            except Exception as e:
+                failures.append({
+                    'record': record,
+                    'error': str(e)
+                })
+    
+    return success_count, failures
+
+def _put_single_record(client, feature_group_name, record):
+    """단일 레코드 저장 (재시도 포함)"""
+    max_retries = 3
+    base_delay = 1
+    
+    for attempt in range(max_retries):
+        try:
+            client.put_record(
+                FeatureGroupName=feature_group_name,
+                Record=[
+                    {'FeatureName': k, 'ValueAsString': str(v)}
+                    for k, v in record.items()
+                ]
+            )
+            return
+        except ClientError as e:
+            if e.response['Error']['Code'] in ['ThrottlingException', 'TooManyRequestsException']:
+                if attempt < max_retries - 1:
+                    delay = base_delay * (2 ** attempt)
+                    time.sleep(delay)
+                    continue
+            raise
+```
+
+### 5. 마이그레이션 계획 수립
+```python
+def _plan_migration(config, source_fg, target_fg, options):
+    """마이그레이션 계획 수립"""
+    
+    source_online = bool(source_fg.get('OnlineStoreConfig'))
+    source_offline = bool(source_fg.get('OfflineStoreConfig'))
+    target_online = bool(target_fg.get('OnlineStoreConfig'))
+    target_offline = bool(target_fg.get('OfflineStoreConfig'))
+    
+    # 소스 타입 결정
+    if source_online and source_offline:
+        source_type = 'online+offline'
+    elif source_online:
+        source_type = 'online'
+    else:
+        source_type = 'offline'
+    
+    # 타겟 타입 결정
+    if target_online and target_offline:
+        target_type = 'online+offline'
+    elif target_online:
+        target_type = 'online'
+    else:
+        target_type = 'offline'
+    
+    # 레코드 수 추정
+    estimated_records = _estimate_record_count(config, source_fg, source_type)
+    
+    # 마이그레이션 전략 결정
+    strategy = _determine_migration_strategy(source_type, target_type)
+    
+    return {
+        'source_type': source_type,
+        'target_type': target_type,
+        'estimated_records': estimated_records,
+        'strategy': strategy,
+        'batch_size': options.get('batch_size', 100),
+        'max_workers': options.get('max_workers', 4),
+        'filter_query': options.get('filter_query')
+    }
+```
+
+## CLI 통합
+
+### cli.py에 추가
+```python
+@cli.command('migrate')
+@click.argument('source_feature_group')
+@click.argument('target_feature_group')
+@click.option('--clear-target', is_flag=True, help='타겟 피처그룹의 기존 데이터 삭제')
+@click.option('--batch-size', default=100, help='배치 처리 사이즈')
+@click.option('--max-workers', default=4, help='동시 처리 워커 수')
+@click.option('--dry-run', is_flag=True, help='실제 마이그레이션 없이 계획만 확인')
+@click.option('--filter-query', help='마이그레이션할 데이터 필터링 (SQL WHERE 절)')
+@click.pass_context
+def migrate_feature_group(ctx, source_feature_group, target_feature_group, 
+                         clear_target, batch_size, max_workers, dry_run, filter_query):
+    """피처 그룹 간 데이터 마이그레이션"""
+    config = ctx.obj['config']
+    migrate_cmd.migrate_feature_group(
+        config, source_feature_group, target_feature_group,
+        clear_target=clear_target, batch_size=batch_size, 
+        max_workers=max_workers, dry_run=dry_run, 
+        filter_query=filter_query
+    )
+```
+
+## 에러 처리 및 복구
+
+### 1. 실패 레코드 추적
+```python
+def _save_failed_records(failed_records, output_file):
+    """실패한 레코드를 파일로 저장"""
+    with open(output_file, 'w') as f:
+        json.dump(failed_records, f, indent=2, default=str)
+
+def _retry_failed_records(config, target_fg, failed_records_file):
+    """실패한 레코드 재시도"""
+    with open(failed_records_file, 'r') as f:
+        failed_records = json.load(f)
+    
+    # 재시도 로직 구현
+```
+
+### 2. 체크포인트 기능
+```python
+def _save_checkpoint(migration_state, checkpoint_file):
+    """마이그레이션 상태 저장"""
+    with open(checkpoint_file, 'w') as f:
+        json.dump(migration_state, f, indent=2, default=str)
+
+def _load_checkpoint(checkpoint_file):
+    """마이그레이션 상태 복원"""
+    try:
+        with open(checkpoint_file, 'r') as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return None
+```
+
+## 구현 단계
+
+### Step 1: migrate_cmd.py 기본 구조 생성
+- 파일 생성 및 기본 함수 틀 구현
+- 스키마 호환성 검증 로직
+
+### Step 2: 오프라인 스토어 추출 구현
+- Athena 쿼리를 통한 데이터 읽기
+- 배치 처리 로직
+
+### Step 3: 온라인 스토어 로드 구현
+- 배치 데이터 병렬 처리
+- 에러 처리 및 재시도
+
+### Step 4: 마이그레이션 계획 및 실행 엔진
+- 전체 마이그레이션 플로우 통합
+
+### Step 5: CLI 통합
+- cli.py에 migrate 명령어 추가
+
+### Step 6: 고급 기능
+- 체크포인트, 재시도, 필터링
+
+## 위험도 및 고려사항
+
+### 위험도: 높음
+- **데이터 일관성**: 마이그레이션 중 데이터 손실 가능
+- **성능 영향**: 대용량 처리 시 시스템 부하
+- **API 제한**: AWS API 호출 제한 도달 가능
+
+### 완화 방안
+1. **배치 처리**: 메모리 효율적인 처리
+2. **재시도 로직**: 일시적 오류 자동 복구
+3. **체크포인트**: 중단 시 재시작 가능
+4. **Dry-run**: 사전 검증으로 위험 최소화
+
+이 계획으로 Migration 기능을 구현할까요?

--- a/feat/migration/enhancement_plan.md
+++ b/feat/migration/enhancement_plan.md
@@ -1,0 +1,145 @@
+# SageMaker Feature Store CLI 개선 계획
+
+## 현재 상황 분석
+
+### 기존 기능
+- **list**: 온라인 피처스토어만 표시 (OnlineStoreConfig가 있는 경우만)
+- **get/put**: 단일 레코드 조회/저장 (온라인 스토어 대상)
+- **bulk-get/bulk-put**: 대량 데이터 조회/저장 (온라인 스토어 대상)
+
+### 코드 구조
+```
+src/sagemaker_fs_cli/
+├── cli.py                 # 메인 CLI 엔트리포인트
+├── config.py              # AWS 설정 관리
+├── commands/              # 각 명령어 구현
+│   ├── list_cmd.py        # 피처그룹 목록 조회
+│   ├── get_cmd.py         # 단일 레코드 조회
+│   ├── put_cmd.py         # 단일 레코드 저장
+│   ├── bulk_get_cmd.py    # 대량 조회
+│   └── bulk_put_cmd.py    # 대량 저장
+└── utils/                 # 유틸리티
+    ├── formatter.py       # 출력 포맷팅
+    └── file_handler.py    # 파일 처리
+```
+
+## 요구사항
+
+### 1. List 기능 개선
+- **현재**: 온라인 스토어가 활성화된 피처그룹만 표시
+- **변경**: 오프라인 전용 피처그룹도 표시
+- **구현**: `list_cmd.py`의 필터 조건 수정
+
+### 2. Migration 기능 추가
+새로운 `migrate` 명령어 추가:
+- **Offline → Online+Offline**: 오프라인 전용 → 온라인+오프라인 구조
+- **Online+Offline → Online+Offline**: 기존 데이터 마이그레이션
+- **옵션**: `--clear-target` 플래그로 대상 삭제 후 진행
+
+### 3. Clear 기능 추가
+새로운 `clear` 명령어 추가:
+- 피처스토어의 모든 데이터 삭제
+- 온라인/오프라인 스토어 선택적 삭제 지원
+
+## 상세 구현 계획
+
+### Phase 1: List 기능 개선
+**파일**: `src/sagemaker_fs_cli/commands/list_cmd.py`
+
+**변경사항**:
+```python
+# 기존: OnlineStoreConfig가 있는 경우만 포함
+if fg_details.get('OnlineStoreConfig'):
+
+# 변경: 모든 피처그룹 포함 (온라인 또는 오프라인 스토어가 있는 경우)
+if fg_details.get('OnlineStoreConfig') or fg_details.get('OfflineStoreConfig'):
+```
+
+**추가 정보 표시**:
+- 스토어 타입 구분 (Online Only, Offline Only, Online+Offline)
+- 오프라인 전용 그룹의 추가 정보
+
+### Phase 2: Migration 기능 구현
+**새 파일**: `src/sagemaker_fs_cli/commands/migrate_cmd.py`
+
+**주요 기능**:
+1. **소스 검증**: 소스 피처그룹 존재 및 타입 확인
+2. **타겟 검증**: 타겟 피처그룹 존재 및 호환성 확인
+3. **스키마 검증**: 피처 정의 호환성 확인
+4. **데이터 마이그레이션**:
+   - 오프라인 스토어에서 데이터 읽기 (S3/Athena)
+   - 배치 처리로 온라인 스토어에 저장
+5. **진행상황 모니터링**
+
+**CLI 인터페이스**:
+```bash
+sagemaker-fs migrate <source-feature-group> <target-feature-group> [OPTIONS]
+
+OPTIONS:
+  --clear-target    타겟 피처그룹의 기존 데이터 삭제
+  --batch-size      배치 처리 사이즈 (기본: 100)
+  --max-workers     동시 처리 워커 수 (기본: 4)
+  --dry-run         실제 실행 없이 계획만 확인
+```
+
+### Phase 3: Clear 기능 구현
+**새 파일**: `src/sagemaker_fs_cli/commands/clear_cmd.py`
+
+**주요 기능**:
+1. **온라인 스토어 클리어**: 모든 레코드 삭제
+2. **오프라인 스토어 클리어**: S3 데이터 삭제
+3. **안전장치**: 확인 프롬프트 및 백업 옵션
+
+**CLI 인터페이스**:
+```bash
+sagemaker-fs clear <feature-group-name> [OPTIONS]
+
+OPTIONS:
+  --online-only     온라인 스토어만 삭제
+  --offline-only    오프라인 스토어만 삭제
+  --force           확인 없이 즉시 삭제
+  --backup-s3       삭제 전 S3에 백업
+```
+
+## 구현 순서
+
+### 1단계: List 기능 개선 ✅ 먼저 구현
+- 영향도: 낮음
+- 구현 복잡도: 낮음
+- 다른 기능의 기반이 됨
+
+### 2단계: Clear 기능 구현
+- 영향도: 중간
+- 구현 복잡도: 중간
+- Migration 기능에서 활용 가능
+
+### 3단계: Migration 기능 구현
+- 영향도: 높음
+- 구현 복잡도: 높음
+- 다른 기능들을 활용
+
+## 리스크 및 고려사항
+
+### 기술적 리스크
+1. **대용량 데이터 처리**: 메모리 및 처리 시간 제한
+2. **API 제한**: SageMaker API 호출 제한
+3. **데이터 일관성**: 마이그레이션 중 데이터 손실 방지
+
+### 운영 리스크
+1. **데이터 손실**: Clear/Migration 시 실수로 인한 데이터 손실
+2. **성능 영향**: 대용량 마이그레이션 시 시스템 부하
+
+### 해결책
+1. **배치 처리**: 대용량 데이터를 작은 단위로 분할 처리
+2. **재시도 로직**: API 제한 및 일시적 오류 처리
+3. **백업 및 검증**: 데이터 손실 방지를 위한 안전장치
+4. **Dry-run 모드**: 실제 실행 전 계획 확인
+
+## 다음 단계
+
+1. **1단계 구현 확인**: List 기능 개선 승인
+2. **2단계 구현 확인**: Clear 기능 설계 검토
+3. **3단계 구현 확인**: Migration 기능 상세 설계
+4. **순차적 구현**: 각 단계별 구현 및 테스트
+
+각 단계마다 사용자 승인을 받고 진행하겠습니다.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ click>=8.0.0
 pandas>=1.5.0
 tabulate>=0.9.0
 pydantic>=2.0.0
+tqdm>=4.65.0

--- a/src/sagemaker_fs_cli/commands/__init__.py
+++ b/src/sagemaker_fs_cli/commands/__init__.py
@@ -1,5 +1,5 @@
 """Command modules for SageMaker FeatureStore CLI"""
 
-from . import list_cmd, get_cmd, put_cmd, bulk_get_cmd, bulk_put_cmd
+from . import list_cmd, get_cmd, put_cmd, bulk_get_cmd, bulk_put_cmd, clear_cmd, migrate_cmd
 
-__all__ = ['list_cmd', 'get_cmd', 'put_cmd', 'bulk_get_cmd', 'bulk_put_cmd']
+__all__ = ['list_cmd', 'get_cmd', 'put_cmd', 'bulk_get_cmd', 'bulk_put_cmd', 'clear_cmd', 'migrate_cmd']

--- a/src/sagemaker_fs_cli/commands/bulk_get_cmd.py
+++ b/src/sagemaker_fs_cli/commands/bulk_get_cmd.py
@@ -2,8 +2,7 @@
 
 import click
 import os
-from datetime import datetime, timezone
-from zoneinfo import ZoneInfo
+from datetime import datetime, timezone, timedelta
 from typing import List, Optional, Dict, Any
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from botocore.exceptions import ClientError
@@ -45,10 +44,9 @@ def get_single_record(config: Config, feature_group_name: str, record_id: str,
 
 
 def replace_time_field_with_current(records: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Replace Time field with current timestamp in KST (Asia/Seoul) timezone"""
-    # Get current time in KST (Asia/Seoul)
-    kst_timezone = ZoneInfo("Asia/Seoul")
-    current_timestamp = datetime.now(kst_timezone).strftime('%Y-%m-%dT%H:%M:%SZ')
+    """Replace Time field with current timestamp in UTC timezone"""
+    # Get current time in UTC
+    current_timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
     
     for record in records:
         if 'Time' in record:

--- a/src/sagemaker_fs_cli/commands/clear_cmd.py
+++ b/src/sagemaker_fs_cli/commands/clear_cmd.py
@@ -1,0 +1,434 @@
+"""Clear command implementation"""
+
+import time
+import click
+from typing import Dict, Any, List, Optional, Tuple
+from botocore.exceptions import ClientError
+from urllib.parse import urlparse
+from tqdm import tqdm
+
+from ..config import Config
+
+
+def _find_athena_table_name(config: Config, database: str, feature_group_name: str) -> Optional[str]:
+    """Find the actual Athena table name for a feature group"""
+    try:
+        athena_client = config.session.client('athena')
+        
+        # List all tables in the database
+        response = athena_client.list_table_metadata(
+            CatalogName='AwsDataCatalog',
+            DatabaseName=database
+        )
+        
+        # Common transformation patterns SageMaker might use
+        possible_names = [
+            feature_group_name.replace('-', '_'),  # Original logic
+            feature_group_name.replace('-', '_').lower(),  # Lowercase
+            feature_group_name,  # No transformation
+            feature_group_name.lower(),  # Just lowercase
+        ]
+        
+        # Get actual table names
+        table_names = [table['Name'] for table in response.get('TableMetadataList', [])]
+        
+        # Try exact matches first
+        for possible_name in possible_names:
+            if possible_name in table_names:
+                return possible_name
+        
+        # Try partial matches (in case there are prefixes/suffixes)
+        feature_group_base = feature_group_name.replace('-', '_').lower()
+        for table_name in table_names:
+            if feature_group_base in table_name.lower():
+                return table_name
+        
+        # If no match found, show available tables for debugging
+        click.echo(f"⚠️  사용 가능한 테이블: {table_names[:5]}...")  # Show first 5
+        return None
+        
+    except Exception as e:
+        click.echo(f"⚠️  테이블 목록 조회 실패: {e}")
+        return None
+
+
+def _get_athena_output_location(config: Config) -> str:
+    """Get suitable S3 location for Athena query results"""
+    try:
+        # Try to use SageMaker default bucket
+        session = config.session
+        region = session.region_name or 'us-east-1'
+        account_id = session.client('sts').get_caller_identity()['Account']
+        
+        # Try common SageMaker bucket patterns
+        bucket_patterns = [
+            f"sagemaker-{region}-{account_id}",
+            f"aws-athena-query-results-{account_id}-{region}",
+            f"sagemaker-studio-{account_id}-{region}"
+        ]
+        
+        s3_client = session.client('s3')
+        
+        for bucket_name in bucket_patterns:
+            try:
+                s3_client.head_bucket(Bucket=bucket_name)
+                return f"s3://{bucket_name}/athena-results/"
+            except:
+                continue
+        
+        # If no bucket found, try to list and use the first available bucket
+        response = s3_client.list_buckets()
+        if response['Buckets']:
+            first_bucket = response['Buckets'][0]['Name']
+            return f"s3://{first_bucket}/athena-results/"
+        
+        # Fallback - this will likely fail but gives a clear error
+        return f"s3://sagemaker-{region}-{account_id}/athena-results/"
+        
+    except Exception as e:
+        # Fallback to original
+        return 's3://temp-query-results/'
+
+
+def clear_feature_group(config: Config, feature_group_name: str, online_only: bool = False, 
+                       offline_only: bool = False, force: bool = False, 
+                       backup_s3: Optional[str] = None, dry_run: bool = False) -> None:
+    """Clear all data from a feature group"""
+    try:
+        # Validate feature group exists and get details
+        fg_details = _validate_feature_group(config, feature_group_name)
+        
+        # Determine what to clear
+        clear_online = not offline_only
+        clear_offline = not online_only
+        
+        # Validate options
+        if not fg_details.get('OnlineStoreConfig') and clear_online:
+            click.echo(f"경고: '{feature_group_name}'에 온라인 스토어가 구성되어 있지 않습니다.", err=True)
+            clear_online = False
+            
+        if not fg_details.get('OfflineStoreConfig') and clear_offline:
+            click.echo(f"경고: '{feature_group_name}'에 오프라인 스토어가 구성되어 있지 않습니다.", err=True)
+            clear_offline = False
+            
+        if not clear_online and not clear_offline:
+            click.echo("삭제할 스토어가 없습니다.", err=True)
+            return
+            
+        # Show plan
+        _show_clear_plan(feature_group_name, clear_online, clear_offline, backup_s3)
+        
+        if dry_run:
+            click.echo("\n🔍 Dry-run 모드: 실제 삭제는 수행되지 않습니다.")
+            return
+            
+        # Confirm deletion
+        if not force and not _confirm_deletion(feature_group_name, clear_online, clear_offline):
+            click.echo("작업이 취소되었습니다.")
+            return
+            
+        # Backup if requested
+        if backup_s3 and clear_offline:
+            click.echo(f"\n📦 오프라인 데이터를 {backup_s3}에 백업 중...")
+            _backup_to_s3(config, feature_group_name, backup_s3, fg_details)
+            
+        # Execute coordinated clear: offline record IDs → online deletion → offline deletion
+        _execute_coordinated_clear(config, feature_group_name, fg_details, clear_online, clear_offline)
+            
+        click.echo(f"\n✅ '{feature_group_name}' 데이터 삭제가 완료되었습니다.")
+        
+    except ClientError as e:
+        click.echo(f"AWS API 오류: {e}", err=True)
+        raise click.Abort()
+    except Exception as e:
+        click.echo(f"예상치 못한 오류: {e}", err=True)
+        raise click.Abort()
+
+
+def _validate_feature_group(config: Config, feature_group_name: str) -> Dict[str, Any]:
+    """Validate feature group exists and return details"""
+    try:
+        fg_details = config.sagemaker.describe_feature_group(
+            FeatureGroupName=feature_group_name
+        )
+        return fg_details
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'ResourceNotFound':
+            click.echo(f"피처 그룹 '{feature_group_name}'을 찾을 수 없습니다.", err=True)
+        else:
+            click.echo(f"피처 그룹 정보 조회 실패: {e}", err=True)
+        raise click.Abort()
+
+
+def _show_clear_plan(feature_group_name: str, clear_online: bool, clear_offline: bool, backup_s3: Optional[str]) -> None:
+    """Show what will be cleared"""
+    click.echo(f"\n📋 삭제 계획: '{feature_group_name}'")
+    click.echo("=" * 50)
+    
+    if clear_online:
+        click.echo("• 온라인 스토어: 모든 레코드 삭제")
+    if clear_offline:
+        click.echo("• 오프라인 스토어: S3 데이터 삭제")
+    if backup_s3:
+        click.echo(f"• 백업 위치: {backup_s3}")
+
+
+def _confirm_deletion(feature_group_name: str, clear_online: bool, clear_offline: bool) -> bool:
+    """Ask user confirmation"""
+    stores_to_clear = []
+    if clear_online:
+        stores_to_clear.append("온라인 스토어")
+    if clear_offline:
+        stores_to_clear.append("오프라인 스토어")
+        
+    stores_str = ", ".join(stores_to_clear)
+    
+    click.echo(f"\n⚠️  경고: '{feature_group_name}'의 {stores_str} 데이터가 완전히 삭제됩니다.")
+    click.echo("이 작업은 되돌릴 수 없습니다!")
+    
+    return click.confirm("\n정말로 계속하시겠습니까?")
+
+
+def _backup_to_s3(config: Config, feature_group_name: str, backup_path: str, fg_details: Dict[str, Any]) -> None:
+    """Backup offline store data to S3"""
+    if not fg_details.get('OfflineStoreConfig'):
+        return
+        
+    try:
+        s3_client = config.session.client('s3')
+        
+        # Get source S3 path
+        source_s3_uri = fg_details['OfflineStoreConfig']['S3StorageConfig']['S3Uri']
+        source_bucket, source_prefix = _parse_s3_uri(source_s3_uri)
+        
+        # Parse backup path
+        backup_bucket, backup_prefix = _parse_s3_uri(backup_path)
+        if backup_prefix and not backup_prefix.endswith('/'):
+            backup_prefix += '/'
+        backup_prefix += f"{feature_group_name}/"
+        
+        # Copy all objects
+        paginator = s3_client.get_paginator('list_objects_v2')
+        objects_copied = 0
+        
+        for page in paginator.paginate(Bucket=source_bucket, Prefix=source_prefix):
+            if 'Contents' not in page:
+                continue
+                
+            for obj in tqdm(page['Contents'], desc="백업 중"):
+                source_key = obj['Key']
+                # Remove source prefix and add backup prefix
+                relative_key = source_key[len(source_prefix):].lstrip('/')
+                backup_key = backup_prefix + relative_key
+                
+                copy_source = {'Bucket': source_bucket, 'Key': source_key}
+                s3_client.copy_object(
+                    CopySource=copy_source,
+                    Bucket=backup_bucket,
+                    Key=backup_key
+                )
+                objects_copied += 1
+                
+        click.echo(f"✅ {objects_copied}개 객체가 백업되었습니다.")
+        
+    except Exception as e:
+        click.echo(f"백업 실패: {e}", err=True)
+        raise
+
+
+def _execute_coordinated_clear(config: Config, feature_group_name: str, fg_details: Dict[str, Any],
+                              clear_online: bool, clear_offline: bool) -> None:
+    """Execute coordinated clear: offline record IDs → online deletion → offline deletion"""
+    
+    record_ids = []
+    
+    # Step 1: Get all record IDs from offline store (if exists and we need them)
+    if fg_details.get('OfflineStoreConfig') and clear_online:
+        click.echo("\n📊 오프라인 스토어에서 레코드 ID 조회 중...")
+        record_ids = _get_record_ids_from_offline_athena(config, fg_details)
+        click.echo(f"✅ {len(record_ids):,}개 record ID 조회 완료")
+    
+    # Step 2: Delete online records using the record IDs
+    if clear_online:
+        click.echo("\n🗑️  온라인 스토어 데이터 삭제 중...")
+        if record_ids:
+            _delete_online_records_by_ids(config, feature_group_name, record_ids)
+        elif not fg_details.get('OfflineStoreConfig'):
+            click.echo("⚠️  온라인 전용 피처그룹은 record ID 목록이 필요합니다.")
+            click.echo("💡 대안: bulk-get으로 모든 데이터를 조회한 후 record ID를 추출하여 삭제하세요.")
+        else:
+            click.echo("⚠️  Record ID가 없어 온라인 삭제를 건너뜁니다.")
+    
+    # Step 3: Delete offline data
+    if clear_offline:
+        click.echo("\n🗑️  오프라인 스토어 데이터 삭제 중...")
+        _delete_offline_s3_data(config, fg_details)
+
+
+def _get_record_ids_from_offline_athena(config: Config, fg_details: Dict[str, Any]) -> List[str]:
+    """Get all unique record IDs from offline store via Athena"""
+    try:
+        athena_client = config.session.client('athena')
+        
+        # Construct query to get unique record IDs
+        database_name = "sagemaker_featurestore"
+        feature_group_name = fg_details['FeatureGroupName']
+        record_id_feature = fg_details['RecordIdentifierFeatureName']
+        
+        # Find actual table name
+        table_name = _find_athena_table_name(config, database_name, feature_group_name)
+        if not table_name:
+            click.echo(f"⚠️  Athena 테이블을 찾을 수 없습니다: {feature_group_name}")
+            return []
+        
+        query = f"SELECT DISTINCT {record_id_feature} FROM {database_name}.{table_name}"
+        
+        # Execute query
+        response = athena_client.start_query_execution(
+            QueryString=query,
+            ResultConfiguration={
+                'OutputLocation': _get_athena_output_location(config)
+            }
+        )
+        
+        query_execution_id = response['QueryExecutionId']
+        
+        # Wait for query completion
+        _wait_for_athena_query_completion(athena_client, query_execution_id)
+        
+        # Get results
+        record_ids = []
+        paginator = athena_client.get_paginator('get_query_results')
+        
+        for page in paginator.paginate(QueryExecutionId=query_execution_id):
+            rows = page['ResultSet']['Rows'][1:]  # Skip header row
+            for row in rows:
+                if row['Data'] and row['Data'][0].get('VarCharValue'):
+                    record_ids.append(row['Data'][0]['VarCharValue'])
+        
+        return record_ids
+        
+    except Exception as e:
+        click.echo(f"Athena를 통한 레코드 ID 조회 실패: {e}", err=True)
+        return []
+
+
+def _delete_online_records_by_ids(config: Config, feature_group_name: str, record_ids: List[str]) -> None:
+    """Delete online records by record IDs"""
+    if not record_ids:
+        click.echo("삭제할 레코드가 없습니다.")
+        return
+        
+    featurestore_runtime = config.session.client('sagemaker-featurestore-runtime')
+    failed_deletions = []
+    
+    with tqdm(total=len(record_ids), desc="온라인 레코드 삭제 중") as pbar:
+        for record_id in record_ids:
+            try:
+                _handle_throttling(
+                    featurestore_runtime.delete_record,
+                    FeatureGroupName=feature_group_name,
+                    RecordIdentifierValueAsString=str(record_id)
+                )
+                pbar.update(1)
+            except Exception as e:
+                failed_deletions.append((record_id, str(e)))
+                pbar.update(1)
+                
+    if failed_deletions:
+        click.echo(f"⚠️  {len(failed_deletions)}개 레코드 삭제 실패:")
+        for record_id, error in failed_deletions[:5]:  # Show first 5 failures
+            click.echo(f"  - {record_id}: {error}")
+        if len(failed_deletions) > 5:
+            click.echo(f"  ... 그 외 {len(failed_deletions) - 5}개")
+    else:
+        click.echo("✅ 모든 온라인 레코드가 삭제되었습니다.")
+
+
+def _delete_offline_s3_data(config: Config, fg_details: Dict[str, Any]) -> None:
+    """Delete all data from offline store (S3)"""
+    if not fg_details.get('OfflineStoreConfig'):
+        return
+        
+    try:
+        s3_client = config.session.client('s3')
+        
+        # Get S3 path
+        s3_uri = fg_details['OfflineStoreConfig']['S3StorageConfig']['S3Uri']
+        bucket, prefix = _parse_s3_uri(s3_uri)
+        
+        # Delete all objects
+        paginator = s3_client.get_paginator('list_objects_v2')
+        objects_deleted = 0
+        
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            if 'Contents' not in page:
+                continue
+                
+            # Delete in batches of 1000 (S3 limit)
+            objects = page['Contents']
+            for i in tqdm(range(0, len(objects), 1000), desc="S3 객체 삭제 중"):
+                batch = objects[i:i+1000]
+                delete_objects = [{'Key': obj['Key']} for obj in batch]
+                
+                s3_client.delete_objects(
+                    Bucket=bucket,
+                    Delete={'Objects': delete_objects}
+                )
+                objects_deleted += len(delete_objects)
+                
+        click.echo(f"✅ {objects_deleted}개 S3 객체가 삭제되었습니다.")
+        
+    except Exception as e:
+        click.echo(f"오프라인 스토어 삭제 실패: {e}", err=True)
+        raise
+
+
+def _wait_for_athena_query_completion(athena_client, query_execution_id: str) -> None:
+    """Wait for Athena query to complete"""
+    max_wait_time = 300  # 5 minutes
+    wait_time = 0
+    
+    while wait_time < max_wait_time:
+        response = athena_client.get_query_execution(QueryExecutionId=query_execution_id)
+        status = response['QueryExecution']['Status']['State']
+        
+        if status == 'SUCCEEDED':
+            return
+        elif status in ['FAILED', 'CANCELLED']:
+            reason = response['QueryExecution']['Status'].get('StateChangeReason', 'Unknown error')
+            raise Exception(f"Athena 쿼리 실패: {reason}")
+        
+        time.sleep(2)
+        wait_time += 2
+    
+    raise Exception(f"Athena 쿼리 타임아웃 (>{max_wait_time}초)")
+
+
+
+
+def _parse_s3_uri(s3_uri: str) -> Tuple[str, str]:
+    """Parse S3 URI into bucket and prefix"""
+    parsed = urlparse(s3_uri)
+    bucket = parsed.netloc
+    prefix = parsed.path.lstrip('/')
+    return bucket, prefix
+
+
+def _handle_throttling(func, *args, **kwargs):
+    """Handle API throttling with exponential backoff"""
+    max_retries = 5
+    base_delay = 1
+    
+    for attempt in range(max_retries):
+        try:
+            return func(*args, **kwargs)
+        except ClientError as e:
+            if e.response['Error']['Code'] in ['ThrottlingException', 'TooManyRequestsException']:
+                if attempt < max_retries - 1:
+                    delay = base_delay * (2 ** attempt)
+                    time.sleep(delay)
+                    continue
+            raise
+    
+    raise Exception(f"Max retries ({max_retries}) exceeded")

--- a/src/sagemaker_fs_cli/commands/list_cmd.py
+++ b/src/sagemaker_fs_cli/commands/list_cmd.py
@@ -8,7 +8,7 @@ from ..utils.formatter import OutputFormatter
 
 
 def list_feature_groups(config: Config, output_format: str) -> None:
-    """List all feature groups with online store enabled"""
+    """List all feature groups with online or offline store enabled"""
     try:
         feature_groups = []
         paginator = config.sagemaker.get_paginator('list_feature_groups')
@@ -21,14 +21,14 @@ def list_feature_groups(config: Config, output_format: str) -> None:
                         FeatureGroupName=fg['FeatureGroupName']
                     )
                     
-                    # Only include feature groups with online store enabled
-                    if fg_details.get('OnlineStoreConfig'):
-                        online_config = fg_details.get('OnlineStoreConfig', {})
-                        offline_config = fg_details.get('OfflineStoreConfig', {})
-                        
-                        # Extract detailed online store information
-                        storage_type = online_config.get('StorageType', 'Standard')
-                        ttl_duration = online_config.get('TtlDuration')
+                    # Include feature groups with online or offline store enabled
+                    online_config = fg_details.get('OnlineStoreConfig', {})
+                    offline_config = fg_details.get('OfflineStoreConfig', {})
+                    
+                    if online_config or offline_config:
+                        # Extract detailed online store information (if available)
+                        storage_type = online_config.get('StorageType', 'N/A') if online_config else 'N/A'
+                        ttl_duration = online_config.get('TtlDuration') if online_config else None
                         if ttl_duration:
                             ttl_value = f"{ttl_duration.get('Value', 'N/A')} {ttl_duration.get('Unit', '')}"
                         else:
@@ -64,7 +64,7 @@ def list_feature_groups(config: Config, output_format: str) -> None:
                     click.echo(f"경고: 피처 그룹 {fg['FeatureGroupName']} 정보를 가져올 수 없습니다: {e}", err=True)
         
         if not feature_groups:
-            click.echo("온라인 피처 그룹을 찾을 수 없습니다.")
+            click.echo("피처 그룹을 찾을 수 없습니다.")
             return
         
         if output_format == 'table':

--- a/src/sagemaker_fs_cli/commands/migrate_cmd.py
+++ b/src/sagemaker_fs_cli/commands/migrate_cmd.py
@@ -1,0 +1,724 @@
+"""Migration command implementation"""
+
+import json
+import time
+import click
+from typing import Dict, Any, List, Optional, Generator, Tuple
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from botocore.exceptions import ClientError
+from tqdm import tqdm
+import pandas as pd
+
+from ..config import Config
+
+
+def _find_athena_table_name(config: Config, database: str, feature_group_name: str) -> Optional[str]:
+    """Find the actual Athena table name for a feature group"""
+    try:
+        athena_client = config.session.client('athena')
+        
+        # List all tables in the database
+        response = athena_client.list_table_metadata(
+            CatalogName='AwsDataCatalog',
+            DatabaseName=database
+        )
+        
+        # Common transformation patterns SageMaker might use
+        possible_names = [
+            feature_group_name.replace('-', '_'),  # Original logic
+            feature_group_name.replace('-', '_').lower(),  # Lowercase
+            feature_group_name,  # No transformation
+            feature_group_name.lower(),  # Just lowercase
+        ]
+        
+        # Get actual table names
+        table_names = [table['Name'] for table in response.get('TableMetadataList', [])]
+        
+        # Try exact matches first
+        for possible_name in possible_names:
+            if possible_name in table_names:
+                return possible_name
+        
+        # Try partial matches (in case there are prefixes/suffixes)
+        feature_group_base = feature_group_name.replace('-', '_').lower()
+        for table_name in table_names:
+            if feature_group_base in table_name.lower():
+                return table_name
+        
+        # If no match found, show available tables for debugging
+        click.echo(f"⚠️  사용 가능한 테이블: {table_names[:5]}...")  # Show first 5
+        return None
+        
+    except Exception as e:
+        click.echo(f"⚠️  테이블 목록 조회 실패: {e}")
+        return None
+
+
+def _get_athena_output_location(config: Config) -> str:
+    """Get suitable S3 location for Athena query results"""
+    try:
+        # Try to use SageMaker default bucket
+        session = config.session
+        region = session.region_name or 'us-east-1'
+        account_id = session.client('sts').get_caller_identity()['Account']
+        
+        # Try common SageMaker bucket patterns
+        bucket_patterns = [
+            f"sagemaker-{region}-{account_id}",
+            f"aws-athena-query-results-{account_id}-{region}",
+            f"sagemaker-studio-{account_id}-{region}"
+        ]
+        
+        s3_client = session.client('s3')
+        
+        for bucket_name in bucket_patterns:
+            try:
+                s3_client.head_bucket(Bucket=bucket_name)
+                return f"s3://{bucket_name}/athena-results/"
+            except:
+                continue
+        
+        # If no bucket found, try to list and use the first available bucket
+        response = s3_client.list_buckets()
+        if response['Buckets']:
+            first_bucket = response['Buckets'][0]['Name']
+            return f"s3://{first_bucket}/athena-results/"
+        
+        # Fallback - this will likely fail but gives a clear error
+        return f"s3://sagemaker-{region}-{account_id}/athena-results/"
+        
+    except Exception as e:
+        # Fallback to original
+        return 's3://temp-query-results/'
+
+
+def migrate_feature_group(config: Config, source_name: str, target_name: str,
+                         clear_target: bool = False, batch_size: int = 100,
+                         max_workers: int = 4, dry_run: bool = False,
+                         filter_query: Optional[str] = None) -> None:
+    """Migrate data from source feature group to target feature group"""
+    try:
+        click.echo(f"🚀 피처 그룹 마이그레이션 시작: {source_name} → {target_name}")
+        
+        # Step 1: Validate both feature groups
+        click.echo("\n📋 피처 그룹 정보 확인 중...")
+        source_fg = _validate_feature_group(config, source_name, "source")
+        target_fg = _validate_feature_group(config, target_name, "target")
+        
+        # Step 2: Check compatibility
+        click.echo("\n🔍 스키마 호환성 검사 중...")
+        _validate_migration_compatibility(source_fg, target_fg)
+        click.echo("✅ 스키마 호환성 확인 완료")
+        
+        # Step 3: Plan migration
+        click.echo("\n📊 마이그레이션 계획 수립 중...")
+        migration_plan = _plan_migration(config, source_fg, target_fg, {
+            'batch_size': batch_size,
+            'max_workers': max_workers,
+            'filter_query': filter_query,
+            'clear_target': clear_target
+        })
+        
+        # Step 4: Show plan
+        _show_migration_plan(source_name, target_name, migration_plan)
+        
+        if dry_run:
+            click.echo("\n🔍 Dry-run 모드: 실제 마이그레이션은 수행되지 않습니다.")
+            return
+        
+        # Step 5: Confirm migration
+        if not _confirm_migration(source_name, target_name, migration_plan):
+            click.echo("마이그레이션이 취소되었습니다.")
+            return
+        
+        # Step 6: Clear target if requested
+        if clear_target:
+            click.echo(f"\n🗑️  타겟 피처 그룹 '{target_name}' 데이터 삭제 중...")
+            _clear_target_feature_group(config, target_fg)
+        
+        # Step 7: Execute migration
+        click.echo(f"\n📦 데이터 마이그레이션 실행 중...")
+        result = _execute_migration(config, source_fg, target_fg, migration_plan)
+        
+        # Step 8: Show results
+        _show_migration_results(result)
+        
+    except Exception as e:
+        click.echo(f"\n❌ 마이그레이션 실패: {e}", err=True)
+        raise click.Abort()
+
+
+def _validate_feature_group(config: Config, feature_group_name: str, role: str) -> Dict[str, Any]:
+    """Validate feature group exists and return details"""
+    try:
+        fg_details = config.sagemaker.describe_feature_group(
+            FeatureGroupName=feature_group_name
+        )
+        
+        # Check if it's in the right state
+        status = fg_details['FeatureGroupStatus']
+        if status != 'Created':
+            raise ValueError(f"{role.capitalize()} 피처 그룹 '{feature_group_name}' 상태가 '{status}'입니다. 'Created' 상태여야 합니다.")
+        
+        return fg_details
+        
+    except ClientError as e:
+        if e.response['Error']['Code'] == 'ResourceNotFound':
+            raise ValueError(f"{role.capitalize()} 피처 그룹 '{feature_group_name}'을 찾을 수 없습니다.")
+        else:
+            raise ValueError(f"{role.capitalize()} 피처 그룹 정보 조회 실패: {e}")
+
+
+def _validate_migration_compatibility(source_fg: Dict[str, Any], target_fg: Dict[str, Any]) -> None:
+    """Validate that source and target feature groups are compatible"""
+    
+    # Compare feature definitions
+    source_features = {f['FeatureName']: f for f in source_fg['FeatureDefinitions']}
+    target_features = {f['FeatureName']: f for f in target_fg['FeatureDefinitions']}
+    
+    # Check for missing features in source
+    missing_features = set(target_features.keys()) - set(source_features.keys())
+    if missing_features:
+        raise ValueError(f"타겟에 있지만 소스에 없는 피처: {missing_features}")
+    
+    # Check data type compatibility
+    incompatible_features = []
+    for fname, target_feat in target_features.items():
+        if fname in source_features:
+            source_feat = source_features[fname]
+            if not _is_type_compatible(source_feat['FeatureType'], target_feat['FeatureType']):
+                incompatible_features.append((fname, source_feat['FeatureType'], target_feat['FeatureType']))
+    
+    if incompatible_features:
+        raise ValueError(f"호환되지 않는 피처 타입: {incompatible_features}")
+    
+    # Check RecordIdentifier and EventTime features
+    if source_fg['RecordIdentifierFeatureName'] != target_fg['RecordIdentifierFeatureName']:
+        raise ValueError(f"RecordIdentifierFeatureName이 다릅니다: {source_fg['RecordIdentifierFeatureName']} vs {target_fg['RecordIdentifierFeatureName']}")
+    
+    if source_fg['EventTimeFeatureName'] != target_fg['EventTimeFeatureName']:
+        raise ValueError(f"EventTimeFeatureName이 다릅니다: {source_fg['EventTimeFeatureName']} vs {target_fg['EventTimeFeatureName']}")
+
+
+def _is_type_compatible(source_type: str, target_type: str) -> bool:
+    """Check if source and target feature types are compatible"""
+    # Same type is always compatible
+    if source_type == target_type:
+        return True
+    
+    # Define compatible type mappings
+    compatible_mappings = {
+        'Integral': ['Integral', 'Fractional', 'String'],  # Numbers can convert to string
+        'Fractional': ['Fractional', 'String'],
+        'String': ['String']  # String can only go to string
+    }
+    
+    return target_type in compatible_mappings.get(source_type, [])
+
+
+def _plan_migration(config: Config, source_fg: Dict[str, Any], target_fg: Dict[str, Any], 
+                   options: Dict[str, Any]) -> Dict[str, Any]:
+    """Plan the migration strategy"""
+    
+    # Determine source and target store types
+    source_online = bool(source_fg.get('OnlineStoreConfig'))
+    source_offline = bool(source_fg.get('OfflineStoreConfig'))
+    target_online = bool(target_fg.get('OnlineStoreConfig'))
+    target_offline = bool(target_fg.get('OfflineStoreConfig'))
+    
+    if source_online and source_offline:
+        source_type = 'online+offline'
+    elif source_online:
+        source_type = 'online'
+    else:
+        source_type = 'offline'
+    
+    if target_online and target_offline:
+        target_type = 'online+offline'
+    elif target_online:
+        target_type = 'online'
+    else:
+        target_type = 'offline'
+    
+    # Estimate record count
+    estimated_records = _estimate_record_count(config, source_fg, source_type)
+    
+    # Determine migration strategy
+    if source_type == 'offline' and 'online' in target_type:
+        strategy = 'offline_to_online'
+        primary_source = 'offline'
+    elif 'online' in source_type and 'online' in target_type:
+        strategy = 'online_to_online'
+        primary_source = 'online'  # Use online as primary for faster access
+    else:
+        raise ValueError(f"지원되지 않는 마이그레이션 타입: {source_type} → {target_type}")
+    
+    return {
+        'source_type': source_type,
+        'target_type': target_type,
+        'strategy': strategy,
+        'primary_source': primary_source,
+        'estimated_records': estimated_records,
+        'batch_size': options['batch_size'],
+        'max_workers': options['max_workers'],
+        'filter_query': options.get('filter_query'),
+        'clear_target': options.get('clear_target', False)
+    }
+
+
+def _estimate_record_count(config: Config, source_fg: Dict[str, Any], source_type: str) -> int:
+    """Estimate the number of records to migrate"""
+    
+    if 'offline' in source_type:
+        # Try to get count from offline store via Athena
+        try:
+            return _get_offline_record_count(config, source_fg)
+        except Exception as e:
+            click.echo(f"⚠️  레코드 수 추정 실패: {e}")
+            return 0
+    else:
+        # Online store doesn't have a direct count API
+        click.echo("⚠️  온라인 스토어의 정확한 레코드 수를 미리 알 수 없습니다.")
+        return 0
+
+
+def _get_offline_record_count(config: Config, source_fg: Dict[str, Any]) -> int:
+    """Get record count from offline store via Athena"""
+    
+    athena_client = config.session.client('athena')
+    database = 'sagemaker_featurestore'
+    feature_group_name = source_fg['FeatureGroupName']
+    
+    # Try to find the actual table name
+    table_name = _find_athena_table_name(config, database, feature_group_name)
+    if not table_name:
+        click.echo(f"⚠️  Athena 테이블을 찾을 수 없습니다: {feature_group_name}")
+        return 0
+    
+    query = f"SELECT COUNT(*) as record_count FROM {database}.{table_name}"
+    
+    # Execute query
+    response = athena_client.start_query_execution(
+        QueryString=query,
+        ResultConfiguration={
+            'OutputLocation': _get_athena_output_location(config)
+        }
+    )
+    
+    query_execution_id = response['QueryExecutionId']
+    
+    # Wait for query completion
+    _wait_for_query_completion(athena_client, query_execution_id)
+    
+    # Get result
+    response = athena_client.get_query_results(QueryExecutionId=query_execution_id)
+    rows = response['ResultSet']['Rows']
+    
+    if len(rows) > 1 and rows[1]['Data']:
+        return int(rows[1]['Data'][0]['VarCharValue'])
+    
+    return 0
+
+
+def _show_migration_plan(source_name: str, target_name: str, plan: Dict[str, Any]) -> None:
+    """Display migration plan"""
+    
+    click.echo(f"\n📋 마이그레이션 계획")
+    click.echo("=" * 60)
+    click.echo(f"소스: {source_name} ({plan['source_type']})")
+    click.echo(f"타겟: {target_name} ({plan['target_type']})")
+    click.echo(f"전략: {plan['strategy']}")
+    click.echo(f"주요 데이터 소스: {plan['primary_source']}")
+    click.echo(f"예상 레코드 수: {plan['estimated_records']:,}")
+    click.echo(f"배치 크기: {plan['batch_size']}")
+    click.echo(f"동시 워커 수: {plan['max_workers']}")
+    
+    if plan['filter_query']:
+        click.echo(f"필터: {plan['filter_query']}")
+    
+    if plan['clear_target']:
+        click.echo("⚠️  타겟 데이터 삭제: 예")
+
+
+def _confirm_migration(source_name: str, target_name: str, plan: Dict[str, Any]) -> bool:
+    """Ask for user confirmation"""
+    
+    click.echo(f"\n⚠️  경고: '{source_name}'의 데이터를 '{target_name}'으로 마이그레이션합니다.")
+    
+    if plan['clear_target']:
+        click.echo(f"⚠️  타겟 피처 그룹 '{target_name}'의 기존 데이터가 삭제됩니다!")
+    
+    click.echo("이 작업은 시간이 오래 걸릴 수 있습니다.")
+    
+    return click.confirm("\n계속하시겠습니까?")
+
+
+def _clear_target_feature_group(config: Config, target_fg: Dict[str, Any]) -> None:
+    """Clear target feature group data"""
+    
+    # Import clear functionality
+    from . import clear_cmd
+    
+    target_name = target_fg['FeatureGroupName']
+    
+    try:
+        # Use clear command with force flag
+        clear_cmd.clear_feature_group(
+            config=config,
+            feature_group_name=target_name,
+            online_only=False,
+            offline_only=False,
+            force=True,  # Skip confirmation
+            backup_s3=None,
+            dry_run=False
+        )
+    except Exception as e:
+        click.echo(f"타겟 데이터 삭제 실패: {e}", err=True)
+        raise
+
+
+def _execute_migration(config: Config, source_fg: Dict[str, Any], target_fg: Dict[str, Any],
+                      migration_plan: Dict[str, Any]) -> Dict[str, Any]:
+    """Execute the actual migration"""
+    
+    strategy = migration_plan['strategy']
+    batch_size = migration_plan['batch_size']
+    max_workers = migration_plan['max_workers']
+    
+    total_processed = 0
+    total_failed = 0
+    failed_records = []
+    
+    # Progress bar setup
+    estimated_records = migration_plan['estimated_records']
+    if estimated_records > 0:
+        progress_bar = tqdm(total=estimated_records, desc="마이그레이션 진행")
+    else:
+        progress_bar = tqdm(desc="마이그레이션 진행")
+    
+    try:
+        # Execute based on strategy
+        if strategy == 'offline_to_online':
+            batches = _extract_from_offline_store(config, source_fg, migration_plan)
+        else:  # online_to_online
+            batches = _extract_from_online_store(config, source_fg, migration_plan)
+        
+        # Process each batch
+        for batch in batches:
+            if not batch:
+                continue
+                
+            # Load batch to target
+            success_count, failures = _load_to_target_store(config, target_fg, batch, max_workers)
+            
+            total_processed += len(batch)
+            total_failed += len(failures)
+            failed_records.extend(failures)
+            
+            # Update progress
+            progress_bar.update(len(batch))
+            progress_bar.set_postfix({
+                'Success': f'{success_count}/{len(batch)}',
+                'Failed': len(failures)
+            })
+    
+    finally:
+        progress_bar.close()
+    
+    return {
+        'total_processed': total_processed,
+        'total_success': total_processed - total_failed,
+        'total_failed': total_failed,
+        'failed_records': failed_records,
+        'success_rate': (total_processed - total_failed) / total_processed if total_processed > 0 else 0
+    }
+
+
+def _extract_from_offline_store(config: Config, source_fg: Dict[str, Any], 
+                               migration_plan: Dict[str, Any]) -> Generator[List[Dict], None, None]:
+    """Extract data from offline store via Athena"""
+    
+    athena_client = config.session.client('athena')
+    database = 'sagemaker_featurestore'
+    feature_group_name = source_fg['FeatureGroupName']
+    batch_size = migration_plan['batch_size']
+    
+    # Find actual table name
+    table_name = _find_athena_table_name(config, database, feature_group_name)
+    if not table_name:
+        click.echo(f"⚠️  Athena 테이블을 찾을 수 없습니다: {feature_group_name}")
+        return
+    
+    # Build query
+    base_query = f"SELECT * FROM {database}.{table_name}"
+    filter_query = migration_plan.get('filter_query')
+    if filter_query:
+        query = f"{base_query} {filter_query}"
+    else:
+        query = base_query
+    
+    # Execute query
+    response = athena_client.start_query_execution(
+        QueryString=query,
+        ResultConfiguration={
+            'OutputLocation': _get_athena_output_location(config)
+        }
+    )
+    
+    query_execution_id = response['QueryExecutionId']
+    
+    # Wait for completion
+    _wait_for_query_completion(athena_client, query_execution_id)
+    
+    # Read results in batches
+    paginator = athena_client.get_paginator('get_query_results')
+    current_batch = []
+    
+    for page in paginator.paginate(QueryExecutionId=query_execution_id):
+        rows = page['ResultSet']['Rows']
+        
+        # Skip header row
+        if page['ResultSet']['Rows'] and not current_batch:
+            rows = rows[1:]
+        
+        for row in rows:
+            try:
+                record = _convert_athena_row_to_record(row, source_fg['FeatureDefinitions'])
+                current_batch.append(record)
+                
+                if len(current_batch) >= batch_size:
+                    yield current_batch
+                    current_batch = []
+                    
+            except Exception as e:
+                click.echo(f"⚠️  레코드 변환 실패: {e}")
+                continue
+    
+    # Yield remaining records
+    if current_batch:
+        yield current_batch
+
+
+def _extract_from_online_store(config: Config, source_fg: Dict[str, Any], 
+                              migration_plan: Dict[str, Any]) -> Generator[List[Dict], None, None]:
+    """Extract data from online store"""
+    
+    # This is more complex as we need to get all record IDs first
+    # For now, we'll use the same Athena approach if offline store exists
+    if source_fg.get('OfflineStoreConfig'):
+        # Use offline store to get record IDs, then fetch from online
+        yield from _extract_hybrid_approach(config, source_fg, migration_plan)
+    else:
+        raise ValueError("온라인 전용 피처 그룹에서 모든 데이터를 추출하는 기능은 현재 지원되지 않습니다. "
+                        "대신 record ID 목록을 제공하거나 bulk-get을 사용해주세요.")
+
+
+def _extract_hybrid_approach(config: Config, source_fg: Dict[str, Any], 
+                            migration_plan: Dict[str, Any]) -> Generator[List[Dict], None, None]:
+    """Extract using both online and offline stores"""
+    
+    # Get record IDs from offline store
+    record_ids = _get_record_ids_from_offline(config, source_fg, migration_plan)
+    
+    # Fetch records from online store in batches
+    featurestore_runtime = config.session.client('sagemaker-featurestore-runtime')
+    source_name = source_fg['FeatureGroupName']
+    batch_size = migration_plan['batch_size']
+    
+    current_batch = []
+    
+    for record_id in record_ids:
+        try:
+            response = featurestore_runtime.get_record(
+                FeatureGroupName=source_name,
+                RecordIdentifierValueAsString=str(record_id)
+            )
+            
+            if response.get('Record'):
+                record = {item['FeatureName']: item['ValueAsString'] 
+                         for item in response['Record']}
+                current_batch.append(record)
+                
+                if len(current_batch) >= batch_size:
+                    yield current_batch
+                    current_batch = []
+                    
+        except Exception as e:
+            click.echo(f"⚠️  레코드 {record_id} 조회 실패: {e}")
+            continue
+    
+    if current_batch:
+        yield current_batch
+
+
+def _get_record_ids_from_offline(config: Config, source_fg: Dict[str, Any], 
+                                migration_plan: Dict[str, Any]) -> List[str]:
+    """Get all record IDs from offline store"""
+    
+    athena_client = config.session.client('athena')
+    database = 'sagemaker_featurestore'
+    feature_group_name = source_fg['FeatureGroupName']
+    record_id_feature = source_fg['RecordIdentifierFeatureName']
+    
+    # Find actual table name
+    table_name = _find_athena_table_name(config, database, feature_group_name)
+    if not table_name:
+        click.echo(f"⚠️  Athena 테이블을 찾을 수 없습니다: {feature_group_name}")
+        return []
+    
+    # Build query to get unique record IDs
+    base_query = f"SELECT DISTINCT {record_id_feature} FROM {database}.{table_name}"
+    filter_query = migration_plan.get('filter_query')
+    if filter_query:
+        query = f"{base_query} {filter_query}"
+    else:
+        query = base_query
+    
+    # Execute query
+    response = athena_client.start_query_execution(
+        QueryString=query,
+        ResultConfiguration={
+            'OutputLocation': _get_athena_output_location(config)
+        }
+    )
+    
+    query_execution_id = response['QueryExecutionId']
+    _wait_for_query_completion(athena_client, query_execution_id)
+    
+    # Get results
+    record_ids = []
+    paginator = athena_client.get_paginator('get_query_results')
+    
+    for page in paginator.paginate(QueryExecutionId=query_execution_id):
+        rows = page['ResultSet']['Rows'][1:]  # Skip header
+        for row in rows:
+            if row['Data'] and row['Data'][0].get('VarCharValue'):
+                record_ids.append(row['Data'][0]['VarCharValue'])
+    
+    return record_ids
+
+
+def _load_to_target_store(config: Config, target_fg: Dict[str, Any], records: List[Dict],
+                         max_workers: int) -> Tuple[int, List[Dict]]:
+    """Load batch of records to target store"""
+    
+    if not target_fg.get('OnlineStoreConfig'):
+        raise ValueError("타겟 피처 그룹에 온라인 스토어가 없습니다.")
+    
+    featurestore_runtime = config.session.client('sagemaker-featurestore-runtime')
+    target_name = target_fg['FeatureGroupName']
+    
+    success_count = 0
+    failures = []
+    
+    # Process records in parallel
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_to_record = {
+            executor.submit(_put_single_record, featurestore_runtime, target_name, record): record
+            for record in records
+        }
+        
+        for future in as_completed(future_to_record):
+            record = future_to_record[future]
+            try:
+                future.result()
+                success_count += 1
+            except Exception as e:
+                failures.append({
+                    'record': record,
+                    'error': str(e)
+                })
+    
+    return success_count, failures
+
+
+def _put_single_record(client, feature_group_name: str, record: Dict) -> None:
+    """Put a single record with retry logic"""
+    
+    max_retries = 3
+    base_delay = 1
+    
+    for attempt in range(max_retries):
+        try:
+            # Convert record to SageMaker format
+            sagemaker_record = [
+                {'FeatureName': k, 'ValueAsString': str(v)}
+                for k, v in record.items() if v is not None
+            ]
+            
+            client.put_record(
+                FeatureGroupName=feature_group_name,
+                Record=sagemaker_record
+            )
+            return
+            
+        except ClientError as e:
+            if e.response['Error']['Code'] in ['ThrottlingException', 'TooManyRequestsException']:
+                if attempt < max_retries - 1:
+                    delay = base_delay * (2 ** attempt)
+                    time.sleep(delay)
+                    continue
+            raise
+
+
+def _convert_athena_row_to_record(row: Dict, feature_definitions: List[Dict]) -> Dict:
+    """Convert Athena query result row to feature record"""
+    
+    record = {}
+    
+    # Create a mapping of feature names to their positions
+    # This assumes the query selected features in the same order as feature definitions
+    for i, feature_def in enumerate(feature_definitions):
+        feature_name = feature_def['FeatureName']
+        
+        if i < len(row['Data']) and row['Data'][i].get('VarCharValue'):
+            record[feature_name] = row['Data'][i]['VarCharValue']
+    
+    return record
+
+
+def _wait_for_query_completion(athena_client, query_execution_id: str) -> None:
+    """Wait for Athena query to complete"""
+    
+    max_wait_time = 300  # 5 minutes
+    wait_time = 0
+    
+    while wait_time < max_wait_time:
+        response = athena_client.get_query_execution(QueryExecutionId=query_execution_id)
+        status = response['QueryExecution']['Status']['State']
+        
+        if status == 'SUCCEEDED':
+            return
+        elif status in ['FAILED', 'CANCELLED']:
+            reason = response['QueryExecution']['Status'].get('StateChangeReason', 'Unknown error')
+            raise Exception(f"Athena 쿼리 실패: {reason}")
+        
+        time.sleep(2)
+        wait_time += 2
+    
+    raise Exception(f"Athena 쿼리 타임아웃 (>{max_wait_time}초)")
+
+
+def _show_migration_results(result: Dict[str, Any]) -> None:
+    """Display migration results"""
+    
+    click.echo(f"\n📊 마이그레이션 결과")
+    click.echo("=" * 50)
+    click.echo(f"총 처리된 레코드: {result['total_processed']:,}")
+    click.echo(f"성공: {result['total_success']:,}")
+    click.echo(f"실패: {result['total_failed']:,}")
+    click.echo(f"성공률: {result['success_rate']:.1%}")
+    
+    if result['failed_records']:
+        click.echo(f"\n⚠️  실패한 레코드 (처음 5개):")
+        for i, failure in enumerate(result['failed_records'][:5]):
+            record_id = failure['record'].get('record_id', 'Unknown')
+            click.echo(f"  {i+1}. {record_id}: {failure['error']}")
+        
+        if len(result['failed_records']) > 5:
+            click.echo(f"  ... 그 외 {len(result['failed_records']) - 5}개")
+    
+    if result['total_failed'] == 0:
+        click.echo("\n✅ 마이그레이션이 성공적으로 완료되었습니다!")
+    else:
+        click.echo(f"\n⚠️  마이그레이션이 완료되었지만 {result['total_failed']}개 레코드 실패")


### PR DESCRIPTION
## 요약
SageMaker Feature Store CLI에 포괄적인 관리 기능을 추가합니다.

### 주요 기능
- ✅ **list 개선**: 오프라인 전용 피처스토어도 목록에 표시
- ✅ **clear 명령어**: 피처스토어 데이터 완전 삭제 (안전 기능 포함)
- ✅ **migrate 명령어**: 피처스토어 간 데이터 마이그레이션

### 새로운 CLI 명령어들

#### 1. 개선된 list 명령어
```bash
# 온라인 + 오프라인 피처스토어 모두 표시
sagemaker-fs list
```

#### 2. clear 명령어
```bash
# 모든 데이터 삭제 (확인 프롬프트 포함)
sagemaker-fs clear my-feature-group

# 온라인 스토어만 삭제
sagemaker-fs clear my-feature-group --online-only

# 백업 후 삭제
sagemaker-fs clear my-feature-group --backup-s3 s3://backup/

# 계획만 확인 (실제 삭제 없음)
sagemaker-fs clear my-feature-group --dry-run
```

#### 3. migrate 명령어
```bash
# 기본 마이그레이션
sagemaker-fs migrate source-fg target-fg

# 타겟 데이터 삭제 후 마이그레이션
sagemaker-fs migrate source-fg target-fg --clear-target

# 성능 튜닝
sagemaker-fs migrate source-fg target-fg --batch-size 200 --max-workers 8

# 계획만 확인
sagemaker-fs migrate source-fg target-fg --dry-run
```

## 기술적 개선사항
- **Python 3.8 호환성**: zoneinfo 종속성 제거, 타입 힌트 수정
- **Athena 테이블 자동 탐지**: 강력한 테이블 이름 매핑
- **동적 S3 버킷 탐지**: Athena 쿼리 결과를 위한 적절한 버킷 자동 선택
- **UTC 타임존 사용**: KST 대신 표준 UTC 사용
- **안전 기능**: 확인 프롬프트, dry-run 모드, 백업 옵션

## 테스트 계획
- [x] 온라인+오프라인 피처그룹에서 list 테스트
- [x] 오프라인 전용 피처그룹에서 list 테스트
- [x] clear 명령어 dry-run 모드 테스트
- [x] migrate 명령어 스키마 호환성 검사 테스트
- [x] 12,372개 레코드 마이그레이션 계획 수립 성공

🤖 Generated with [Claude Code](https://claude.ai/code)