### PR TITLE
CLI 명령어 help에 사용 예제 추가

### DIFF
--- a/src/sagemaker_fs_cli/cli.py
+++ b/src/sagemaker_fs_cli/cli.py
@@ -21,7 +21,15 @@ def cli(ctx, profile: Optional[str], region: Optional[str]):
               help='출력 형식')
 @click.pass_context
 def list_feature_groups(ctx, output_format: str):
-    """모든 피처 그룹 목록 조회 (온라인/오프라인)"""
+    """모든 피처 그룹 목록 조회 (온라인/오프라인)
+    
+    예제:
+      # 테이블 형태로 출력
+      fs list
+      
+      # JSON 형태로 출력
+      fs list --output-format json
+    """
     config = ctx.obj['config']
     list_cmd.list_feature_groups(config, output_format)
 
@@ -35,7 +43,18 @@ def list_feature_groups(ctx, output_format: str):
 @click.pass_context
 def get_record(ctx, feature_group_name: str, record_identifier_value: str, 
                feature_names: Optional[str], output_format: str):
-    """피처 그룹에서 단일 레코드 조회"""
+    """피처 그룹에서 단일 레코드 조회
+    
+    예제:
+      # 기본 조회
+      fs get my-feature-group record-id-123
+      
+      # 특정 피처만 조회
+      fs get my-feature-group record-id-123 --feature-names "feature1,feature2,feature3"
+      
+      # JSON 형태로 출력
+      fs get my-feature-group record-id-123 --output-format json
+    """
     config = ctx.obj['config']
     feature_list = feature_names.split(',') if feature_names else None
     get_cmd.get_record(config, feature_group_name, record_identifier_value, feature_list, output_format)
@@ -46,7 +65,11 @@ def get_record(ctx, feature_group_name: str, record_identifier_value: str,
 @click.option('--record', required=True, help='저장할 레코드의 JSON 문자열')
 @click.pass_context
 def put_record(ctx, feature_group_name: str, record: str):
-    """피처 그룹에 단일 레코드 저장"""
+    """피처 그룹에 단일 레코드 저장
+    
+    예제:
+      fs put my-feature-group --record '{"feature1": "value1", "feature2": "value2", "record_id": "123"}'
+    """
     config = ctx.obj['config']
     put_cmd.put_record(config, feature_group_name, record)
 
@@ -60,7 +83,24 @@ def put_record(ctx, feature_group_name: str, record: str):
 @click.pass_context
 def bulk_get_records(ctx, feature_group_name: str, input_file: str, 
                     output_file: Optional[str], feature_names: Optional[str], current_time: bool):
-    """입력 파일(JSON/CSV)을 사용하여 피처 그룹에서 대량 레코드 조회"""
+    """입력 파일(JSON/CSV)을 사용하여 피처 그룹에서 대량 레코드 조회
+    
+    예제:
+      # JSON 파일에서 레코드 ID 목록을 읽어 조회
+      fs bulk-get my-feature-group input_ids.json
+      
+      # 결과를 파일로 저장
+      fs bulk-get my-feature-group input_ids.json --output-file results.json
+      
+      # CSV 파일 사용
+      fs bulk-get my-feature-group input_ids.csv --output-file results.csv
+      
+      # 특정 피처만 조회
+      fs bulk-get my-feature-group input_ids.json --feature-names "feature1,feature2"
+      
+      # 현재 시간으로 Time 필드 교체
+      fs bulk-get my-feature-group input_ids.json --current-time
+    """
     config = ctx.obj['config']
     feature_list = feature_names.split(',') if feature_names else None
     bulk_get_cmd.bulk_get_records(config, feature_group_name, input_file, output_file, feature_list, current_time)
@@ -72,7 +112,18 @@ def bulk_get_records(ctx, feature_group_name: str, input_file: str,
 @click.option('--output-file', '-o', help='결과 로그를 저장할 파일 경로')
 @click.pass_context
 def bulk_put_records(ctx, feature_group_name: str, input_file: str, output_file: Optional[str]):
-    """입력 파일(JSON/CSV)을 사용하여 피처 그룹에 대량 레코드 저장"""
+    """입력 파일(JSON/CSV)을 사용하여 피처 그룹에 대량 레코드 저장
+    
+    예제:
+      # JSON 파일에서 레코드들을 읽어 업데이트
+      fs bulk-put my-feature-group records.json
+      
+      # CSV 파일 사용
+      fs bulk-put my-feature-group records.csv
+      
+      # 결과 로그를 파일로 저장
+      fs bulk-put my-feature-group records.json --output-file logs.txt
+    """
     config = ctx.obj['config']
     bulk_put_cmd.bulk_put_records(config, feature_group_name, input_file, output_file)
 
@@ -87,7 +138,27 @@ def bulk_put_records(ctx, feature_group_name: str, input_file: str, output_file:
 @click.pass_context
 def clear_feature_group(ctx, feature_group_name: str, online_only: bool, offline_only: bool, 
                        force: bool, backup_s3: Optional[str], dry_run: bool):
-    """피처 그룹의 모든 데이터 삭제"""
+    """피처 그룹의 모든 데이터 삭제
+    
+    예제:
+      # 모든 데이터 삭제 (확인 프롬프트 포함)
+      fs clear my-feature-group
+      
+      # 온라인 스토어만 삭제
+      fs clear my-feature-group --online-only
+      
+      # 오프라인 스토어만 삭제
+      fs clear my-feature-group --offline-only
+      
+      # 백업 후 삭제
+      fs clear my-feature-group --backup-s3 s3://my-backup/fg-backup/
+      
+      # 강제 삭제 (확인 없음)
+      fs clear my-feature-group --force
+      
+      # 계획만 확인 (실제 삭제 없음)
+      fs clear my-feature-group --dry-run
+    """
     if online_only and offline_only:
         click.echo("--online-only와 --offline-only 옵션을 동시에 사용할 수 없습니다.", err=True)
         raise click.Abort()
@@ -109,7 +180,24 @@ def clear_feature_group(ctx, feature_group_name: str, online_only: bool, offline
 def migrate_feature_group(ctx, source_feature_group: str, target_feature_group: str, 
                          clear_target: bool, batch_size: int, max_workers: int, 
                          dry_run: bool, filter_query: Optional[str]):
-    """피처 그룹 간 데이터 마이그레이션"""
+    """피처 그룹 간 데이터 마이그레이션
+    
+    예제:
+      # 기본 마이그레이션
+      fs migrate source-fg target-fg
+      
+      # 타겟 데이터 삭제 후 마이그레이션
+      fs migrate source-fg target-fg --clear-target
+      
+      # 배치 사이즈 조정
+      fs migrate source-fg target-fg --batch-size 50 --max-workers 8
+      
+      # 계획만 확인 (실제 마이그레이션 없음)
+      fs migrate source-fg target-fg --dry-run
+      
+      # 특정 조건의 데이터만 마이그레이션
+      fs migrate source-fg target-fg --filter-query "WHERE created_date >= '2024-01-01'"
+    """
     if batch_size <= 0:
         click.echo("배치 사이즈는 1 이상이어야 합니다.", err=True)
         raise click.Abort()


### PR DESCRIPTION
## 요약
모든 CLI 명령어의 `--help`에 실용적인 사용 예제를 추가하여 사용성을 크게 개선했습니다.

## 변경사항
각 명령어의 docstring에 상세한 사용 예제를 추가:

### 📋 list 명령어
```bash
# 테이블 형태로 출력
fs list

# JSON 형태로 출력  
fs list --output-format json
```

### 🔍 get 명령어
```bash
# 기본 조회
fs get my-feature-group record-id-123

# 특정 피처만 조회
fs get my-feature-group record-id-123 --feature-names "feature1,feature2,feature3"

# JSON 형태로 출력
fs get my-feature-group record-id-123 --output-format json
```

### 💾 put 명령어
```bash
fs put my-feature-group --record '{"feature1": "value1", "feature2": "value2", "record_id": "123"}'
```

### 📦 bulk-get 명령어
```bash
# JSON 파일에서 레코드 ID 목록을 읽어 조회
fs bulk-get my-feature-group input_ids.json

# 결과를 파일로 저장
fs bulk-get my-feature-group input_ids.json --output-file results.json

# CSV 파일 사용
fs bulk-get my-feature-group input_ids.csv --output-file results.csv

# 특정 피처만 조회
fs bulk-get my-feature-group input_ids.json --feature-names "feature1,feature2"

# 현재 시간으로 Time 필드 교체
fs bulk-get my-feature-group input_ids.json --current-time
```

### 🗑️ clear 명령어
```bash
# 모든 데이터 삭제 (확인 프롬프트 포함)
fs clear my-feature-group

# 온라인 스토어만 삭제
fs clear my-feature-group --online-only

# 오프라인 스토어만 삭제
fs clear my-feature-group --offline-only

# 백업 후 삭제
fs clear my-feature-group --backup-s3 s3://my-backup/fg-backup/

# 강제 삭제 (확인 없음)
fs clear my-feature-group --force

# 계획만 확인 (실제 삭제 없음)
fs clear my-feature-group --dry-run
```

### 🔄 migrate 명령어
```bash
# 기본 마이그레이션
fs migrate source-fg target-fg

# 타겟 데이터 삭제 후 마이그레이션
fs migrate source-fg target-fg --clear-target

# 배치 사이즈 조정
fs migrate source-fg target-fg --batch-size 50 --max-workers 8

# 계획만 확인 (실제 마이그레이션 없음)
fs migrate source-fg target-fg --dry-run

# 특정 조건의 데이터만 마이그레이션
fs migrate source-fg target-fg --filter-query "WHERE created_date >= '2024-01-01'"
```

## 사용자 경험 개선
- ✅ **즉시 참조**: README나 문서를 찾을 필요 없이 `fs <command> --help`로 바로 예제 확인
- ✅ **실용적 예제**: 실제 사용 상황을 반영한 구체적인 예제
- ✅ **한국어 지원**: 사용자 친화적인 한국어 설명
- ✅ **모든 명령어 지원**: 7개 모든 명령어에 예제 추가

## 테스트 완료
- [x] `fs list --help`
- [x] `fs get --help`
- [x] `fs put --help`
- [x] `fs bulk-get --help`
- [x] `fs bulk-put --help`  
- [x] `fs clear --help`
- [x] `fs migrate --help`

모든 명령어에서 예제가 정상적으로 표시됨을 확인했습니다.

🤖 Generated with [Claude Code](https://claude.ai/code)